### PR TITLE
Use a groutine to load of state

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,9 +151,13 @@ func monitor(_ *cobra.Command, _ []string) {
 		}
 	}()
 
-	for _, nic := range i.NICCollection {
-		i.hostChan <- nic
-	}
+	// Needs to be run in a Goroutine because of limited number of channels
+	go func() {
+		for _, nic := range i.NICCollection {
+			i.hostChan <- nic
+		}
+		return
+	}()
 
 	_ = g.Run()
 }


### PR DESCRIPTION
Use a groutine to load of state as the limited number of hostChan channels will block if state is bigger than 10.